### PR TITLE
Add dependency on unstable-lib.

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -2,7 +2,7 @@
 (define version "1.0")
 (define collection "puresuri")
 (define deps '("lux"
-               "base" "gui-lib" "pict-lib" "ppict"))
+               "base" "gui-lib" "pict-lib" "ppict" "unstable-lib"))
 (define build-deps '("ppict"
                      "gui-doc"
                      "pict-doc"


### PR DESCRIPTION
unstable/error is moving there as of Racket 6.2.900.17.
This dependency is not necessary for 6.2.1, but will be starting with the next release.
